### PR TITLE
add opt-out Cargo features to remove the default initialization and ...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,16 @@ volatile-register = "0.1.1"
 m = "0.1.0"
 
 [features]
-default = ["compiler-builtins-snapshot/memcpy", "examples"]
+default = [
+    "compiler-builtins-snapshot/memcpy",
+    "default-exception-handler",
+    "default-init",
+    "default-panic-fmt",
+    "examples",
+]
+default-exception-handler = []
+default-init = []
+default-panic-fmt = []
 examples = []
 
 [profile.release]

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -1,8 +1,8 @@
+#[cfg(feature = "default-panic-fmt")]
 use core::fmt::Arguments;
 
-#[export_name = "rust_begin_unwind"]
+#[cfg(feature = "default-panic-fmt")]
 #[lang = "panic_fmt"]
-#[linkage = "weak"]
 unsafe extern "C" fn panic_fmt(msg: Arguments,
                                file: &'static str,
                                line: u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,11 +125,12 @@
 //!
 //! See the [examples](examples/index.html) module.
 
-#![cfg_attr(target_arch = "arm", feature(core_intrinsics))]
+#![cfg_attr(all(target_arch = "arm",
+                feature = "default-exception-handler"),
+            feature(core_intrinsics))]
 #![deny(warnings)]
 #![feature(asm)]
 #![feature(lang_items)]
-#![feature(linkage)]
 #![feature(macro_reexport)]
 #![feature(naked_functions)]
 #![no_std]
@@ -169,10 +170,9 @@ pub struct I16x3 {
 }
 
 // Default initialization routine
+#[cfg(feature = "default-init")]
 #[doc(hidden)]
-#[export_name = "_init"]
-#[linkage = "weak"]
-pub unsafe extern "C" fn init() {
+pub unsafe fn _init() {
     delay::init();
     fpu::init();
     itm::init();
@@ -181,14 +181,6 @@ pub unsafe extern "C" fn init() {
     lsm303dlhc::init();
     serial::init();
     timeit::init();
-}
-
-extern "C" {
-    // `main`, the entry point of the user program
-    // NOTE the right signature of `main` is `fn() -> !`. But the user might get
-    // that wrong so let's err on the side of caution and install a safety net
-    // (see below).
-    fn main();
 }
 
 // Hz


### PR DESCRIPTION
panic handler routines. This way we can stop relying on the #[linkage =
"weak"] feature which is unstable and can't be used to override the
these routines from a dependency (i.e. these routines can only be
overridden from the top crate) because of how linker arguments are
ordered by `rustc`.
