### PR TITLE
compiler-builtins must always be compiled with +memcpy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,19 @@ repository = "https://github.com/japaric/f3"
 version = "0.1.0"
 
 [dependencies]
-compiler-builtins-snapshot = "0.0.20161008"
 cortex-m = "0.1.3"
 r0 = "0.1.0"
 volatile-register = "0.1.1"
+
+[dependencies.compiler-builtins-snapshot]
+features = ["memcpy"]
+version = "0.0.20161008"
 
 [dev-dependencies]
 m = "0.1.0"
 
 [features]
 default = [
-    "compiler-builtins-snapshot/memcpy",
     "default-exception-handler",
     "default-init",
     "default-panic-fmt",


### PR DESCRIPTION
remove it from the list of default features
