### PR TITLE
place the call stack in Core Coupled RAM (CCRAM)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,7 @@ SECTIONS
   .text ORIGIN(FLASH) :
   {
     /* Vector table */
-    LONG(ORIGIN(RAM) + LENGTH(RAM));
+    LONG(ORIGIN(CCRAM) + LENGTH(CCRAM));
     LONG(_reset + 1);
     KEEP(*(.text.exceptions));
     _eexceptions = .;");


### PR DESCRIPTION
this implies that memory allocated on the "stack" can't be used with the
DMA peripheral.

closes #45 

---

I want to do some benchmarks and write some examples that use the DMA before deciding if this a good idea or not.
