### PR TITLE
use pub + export_name for EXCEPTIONS and INTERRUPTS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,12 +27,12 @@ SECTIONS
     /* Vector table */
     LONG(ORIGIN(RAM) + LENGTH(RAM));
     LONG(_reset + 1);
-    KEEP(*(.text.exceptions));
+    KEEP(*(.rodata._EXCEPTIONS));
     _eexceptions = .;");
 
     if interrupts {
         ld.push_str("
-    KEEP(*(.text.interrupts));
+    KEEP(*(.rodata._INTERRUPTS));
     _einterrupts = .;");
     }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -87,8 +87,7 @@ pub unsafe extern "C" fn default_handler(sf: &StackFrame) -> ! {
 /// vector table.
 ///
 /// `None` indicates that the spot is RESERVED.
-#[link_section = ".text.exceptions"]
-#[no_mangle]
+#[export_name = "_EXCEPTIONS"]
 pub static EXCEPTIONS: [Option<Handler>; 14] = [Some(_nmi),
                                                 Some(_hard_fault),
                                                 Some(_memmanage_fault),

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -12,8 +12,7 @@ use cortex_m::Handler;
 /// List of all the interrupts as allocated in the vector table.
 ///
 /// `None` indicates that the spot is RESERVED.
-#[link_section = ".text.interrupts"]
-#[no_mangle]
+#[export_name = "_INTERRUPTS"]
 pub static INTERRUPTS: [Option<Handler>; 85] = [Some(_wwdg),
                                                 Some(_pvd),
                                                 Some(_tamper_stamp),


### PR DESCRIPTION
rather than link_section and no_mangle. This way we don't have to
necessarily use the EXCEPTIONS and INTERRUPTS symbol names.

This also let us change the symbol name behind the exception::EXCEPTIONS
and interrupt::INTERRUPTS static variables without breaking the API and
needing a major version bump.