### PR TITLE
export_name -> no_mangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed the override-panic-fmt example to use the panic_fmt lang item rather
+  than the more unstable symbol name (`rust_begin_unwind`)
+
 ## [v0.3.0] - 2016-11-14
 
 ### Added

--- a/examples/abort.rs
+++ b/examples/abort.rs
@@ -8,7 +8,7 @@ extern crate f3;
 
 use core::intrinsics;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     unsafe { intrinsics::abort() }
 }

--- a/examples/angle-meter.rs
+++ b/examples/angle-meter.rs
@@ -8,7 +8,7 @@ extern crate f3;
 
 use f3::{delay, l3gd20};
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     const GAIN: f32 = 8.75e-3;
     const PERIOD: u16 = 10;

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -65,7 +65,7 @@
 
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // This reads beyond the boundary of available RAM (40KiB starting at
     // 0x4000_0000) and triggers an exception

--- a/examples/fpu.rs
+++ b/examples/fpu.rs
@@ -7,7 +7,7 @@
 #[macro_use]
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     let x = black_box(2.5_f32);
     let y = black_box(3.5_f32);

--- a/examples/i2c-read-multi.rs
+++ b/examples/i2c-read-multi.rs
@@ -9,7 +9,7 @@ extern crate f3;
 
 use f3::peripheral;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // Magnetometer
     const SLAVE_ADDRESS: u8 = 0b001_1110;

--- a/examples/i2c-read-single.rs
+++ b/examples/i2c-read-single.rs
@@ -9,7 +9,7 @@ extern crate f3;
 
 use f3::peripheral;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // Accelerometer
     const SLAVE_ADDRESS: u8 = 0b0011001;

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -55,7 +55,7 @@
 #[macro_use]
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     iprintln!("Hello, world!");
 

--- a/examples/led-compass-1.rs
+++ b/examples/led-compass-1.rs
@@ -10,7 +10,7 @@ use f3::I16x3;
 use f3::led::Direction;
 use f3::{delay, led, lsm303dlhc};
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     loop {
         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/examples/led-compass-2.rs
+++ b/examples/led-compass-2.rs
@@ -10,7 +10,7 @@ use f3::I16x3;
 use f3::led::Direction;
 use f3::{delay, led, lsm303dlhc};
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     loop {
         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/examples/led-compass-3.rs
+++ b/examples/led-compass-3.rs
@@ -15,7 +15,7 @@ use f3::{delay, led, lsm303dlhc};
 
 use m::Float;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     loop {
         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/examples/led-roulette.rs
+++ b/examples/led-roulette.rs
@@ -10,7 +10,7 @@ use core::iter;
 use f3::led::LEDS;
 use f3::delay;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     loop {
         for (current, next) in LEDS.iter()

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -6,7 +6,7 @@
 
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     loop {}
 }

--- a/examples/override-default-exception-handler.rs
+++ b/examples/override-default-exception-handler.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // After you hit this exception ...
     let _exception = unsafe { *((0x4000_0000 + 40 * 1024) as *const u32) };

--- a/examples/override-exception.rs
+++ b/examples/override-exception.rs
@@ -7,7 +7,7 @@
 #[macro_use]
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     let _hard_fault_exception = unsafe {
         // After you hit this exception ...

--- a/examples/override-init.rs
+++ b/examples/override-init.rs
@@ -17,7 +17,7 @@ pub fn init() {
     }
 }
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     unsafe {
         // ... then you'll reach this breakpoint.

--- a/examples/override-interrupt.rs
+++ b/examples/override-interrupt.rs
@@ -9,7 +9,7 @@ extern crate f3;
 
 use f3::delay;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // This function uses the TIM7 interrupt under the hood. After a second has
     // passed, the `_tim7` interrupt handler will be called and ...

--- a/examples/override-panic-fmt.rs
+++ b/examples/override-panic-fmt.rs
@@ -3,6 +3,7 @@
 //! The `default-panic-fmt` Cargo feature must be disabled for this to work.
 
 #![feature(asm)]
+#![feature(lang_items)]
 #![no_main]
 #![no_std]
 
@@ -11,14 +12,13 @@ extern crate f3;
 
 use core::fmt::Arguments;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // Panic here and ...
     panic!("Hello, world!")
 }
 
-#[allow(dead_code)]
-#[export_name = "rust_begin_unwind"]
+#[lang = "panic_fmt"]
 extern "C" fn panic_fmt(_msg: Arguments, _file: &'static str, _line: u32) -> ! {
     unsafe {
         // ... you'll reach this breakpoint!

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -20,7 +20,7 @@
 extern crate cortex_m;
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     panic!("Hello, world!")
 }

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -6,7 +6,7 @@
 #[macro_use]
 extern crate f3;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     uprintln!("The quick brown fox jumps over the lazy dog.");
 

--- a/examples/spi-read-multi.rs
+++ b/examples/spi-read-multi.rs
@@ -8,7 +8,7 @@ extern crate f3;
 
 use f3::peripheral;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // OUT_X_L
     const REGISTER_ADDRESS_START: u8 = 0x28;

--- a/examples/spi-read-single.rs
+++ b/examples/spi-read-single.rs
@@ -8,7 +8,7 @@ extern crate f3;
 
 use f3::peripheral;
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     // WHO_AM_I
     const REGISTER_ADDRESS: u8 = 0x0f;

--- a/examples/timeit.rs
+++ b/examples/timeit.rs
@@ -28,7 +28,7 @@ macro_rules! timeit {
     }
 }
 
-#[export_name = "main"]
+#[no_mangle]
 pub fn main() -> ! {
     timeit!(delay::ms(1_000));
     timeit!(delay::ms(1_000));

--- a/src/examples/abort.rs
+++ b/src/examples/abort.rs
@@ -10,7 +10,7 @@
 //!
 //! use core::intrinsics;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     unsafe { intrinsics::abort() }
 //! }

--- a/src/examples/angle_meter.rs
+++ b/src/examples/angle_meter.rs
@@ -10,7 +10,7 @@
 //!
 //! use f3::{delay, l3gd20};
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     const GAIN: f32 = 8.75e-3;
 //!     const PERIOD: u16 = 10;

--- a/src/examples/exception.rs
+++ b/src/examples/exception.rs
@@ -67,7 +67,7 @@
 //!
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // This reads beyond the boundary of available RAM (40KiB starting at
 //!     // 0x4000_0000) and triggers an exception

--- a/src/examples/fpu.rs
+++ b/src/examples/fpu.rs
@@ -9,7 +9,7 @@
 //! #[macro_use]
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     let x = black_box(2.5_f32);
 //!     let y = black_box(3.5_f32);

--- a/src/examples/i2c_read_multi.rs
+++ b/src/examples/i2c_read_multi.rs
@@ -11,7 +11,7 @@
 //!
 //! use f3::peripheral;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // Magnetometer
 //!     const SLAVE_ADDRESS: u8 = 0b001_1110;

--- a/src/examples/i2c_read_single.rs
+++ b/src/examples/i2c_read_single.rs
@@ -11,7 +11,7 @@
 //!
 //! use f3::peripheral;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // Accelerometer
 //!     const SLAVE_ADDRESS: u8 = 0b0011001;

--- a/src/examples/itm.rs
+++ b/src/examples/itm.rs
@@ -57,7 +57,7 @@
 //! #[macro_use]
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     iprintln!("Hello, world!");
 //!

--- a/src/examples/led_compass_1.rs
+++ b/src/examples/led_compass_1.rs
@@ -12,7 +12,7 @@
 //! use f3::led::Direction;
 //! use f3::{delay, led, lsm303dlhc};
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     loop {
 //!         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/src/examples/led_compass_2.rs
+++ b/src/examples/led_compass_2.rs
@@ -12,7 +12,7 @@
 //! use f3::led::Direction;
 //! use f3::{delay, led, lsm303dlhc};
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     loop {
 //!         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/src/examples/led_compass_3.rs
+++ b/src/examples/led_compass_3.rs
@@ -17,7 +17,7 @@
 //!
 //! use m::Float;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     loop {
 //!         let I16x3 { x, y, .. } = lsm303dlhc::magnetic_field();

--- a/src/examples/led_roulette.rs
+++ b/src/examples/led_roulette.rs
@@ -12,7 +12,7 @@
 //! use f3::led::LEDS;
 //! use f3::delay;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     loop {
 //!         for (current, next) in LEDS.iter()

--- a/src/examples/minimal.rs
+++ b/src/examples/minimal.rs
@@ -8,7 +8,7 @@
 //!
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     loop {}
 //! }

--- a/src/examples/override_default_exception_handler.rs
+++ b/src/examples/override_default_exception_handler.rs
@@ -12,7 +12,7 @@
 //! #[macro_use]
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // After you hit this exception ...
 //!     let _exception = unsafe { *((0x4000_0000 + 40 * 1024) as *const u32) };

--- a/src/examples/override_exception.rs
+++ b/src/examples/override_exception.rs
@@ -9,7 +9,7 @@
 //! #[macro_use]
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     let _hard_fault_exception = unsafe {
 //!         // After you hit this exception ...

--- a/src/examples/override_init.rs
+++ b/src/examples/override_init.rs
@@ -19,7 +19,7 @@
 //!     }
 //! }
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     unsafe {
 //!         // ... then you'll reach this breakpoint.

--- a/src/examples/override_interrupt.rs
+++ b/src/examples/override_interrupt.rs
@@ -11,7 +11,7 @@
 //!
 //! use f3::delay;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // This function uses the TIM7 interrupt under the hood. After a second has
 //!     // passed, the `_tim7` interrupt handler will be called and ...

--- a/src/examples/override_panic_fmt.rs
+++ b/src/examples/override_panic_fmt.rs
@@ -5,6 +5,7 @@
 //!
 //! ``` rust,no_run
 //! #![feature(asm)]
+//! #![feature(lang_items)]
 //! #![no_main]
 //! #![no_std]
 //!
@@ -13,14 +14,13 @@
 //!
 //! use core::fmt::Arguments;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // Panic here and ...
 //!     panic!("Hello, world!")
 //! }
 //!
-//! #[allow(dead_code)]
-//! #[export_name = "rust_begin_unwind"]
+//! #[lang = "panic_fmt"]
 //! extern "C" fn panic_fmt(_msg: Arguments, _file: &'static str, _line: u32) -> ! {
 //!     unsafe {
 //!         // ... you'll reach this breakpoint!

--- a/src/examples/panic.rs
+++ b/src/examples/panic.rs
@@ -22,7 +22,7 @@
 //! extern crate cortex_m;
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     panic!("Hello, world!")
 //! }

--- a/src/examples/serial.rs
+++ b/src/examples/serial.rs
@@ -8,7 +8,7 @@
 //! #[macro_use]
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     uprintln!("The quick brown fox jumps over the lazy dog.");
 //!

--- a/src/examples/spi_read_multi.rs
+++ b/src/examples/spi_read_multi.rs
@@ -10,7 +10,7 @@
 //!
 //! use f3::peripheral;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // OUT_X_L
 //!     const REGISTER_ADDRESS_START: u8 = 0x28;

--- a/src/examples/spi_read_single.rs
+++ b/src/examples/spi_read_single.rs
@@ -10,7 +10,7 @@
 //!
 //! use f3::peripheral;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // WHO_AM_I
 //!     const REGISTER_ADDRESS: u8 = 0x0f;

--- a/src/examples/timeit.rs
+++ b/src/examples/timeit.rs
@@ -30,7 +30,7 @@
 //!     }
 //! }
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     timeit!(delay::ms(1_000));
 //!     timeit!(delay::ms(1_000));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //!
 //! extern crate f3;
 //!
-//! #[export_name = "main"]
+//! #[no_mangle]
 //! pub fn main() -> ! {
 //!     // Your code goes here!
 //!


### PR DESCRIPTION
fix the override-panic-fmt example to use the lang item rather than the
more unstable symbol