### PR TITLE
ld: discard the .note.gnu.build-id section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: rust
 services: docker
 sudo: required
-rust: nightly
+rust: nightly-2016-11-16
 
 matrix:
   include:

--- a/build.rs
+++ b/build.rs
@@ -67,7 +67,8 @@ SECTIONS
     ld.push_str("
   /DISCARD/ :
   {
-    *(.ARM.exidx.*)");
+    *(.ARM.exidx.*)
+    *(.note.gnu.build-id.*)");
 
     if !static_ram {
         ld.push_str("


### PR DESCRIPTION
old versions of gcc insert this into the executable but this causes
problem because this section places itself at the beginning of the .text
section thus filling the vector table with wrong values.