### PR TITLE
ld: add an unused _VECTOR_TABLE variable to get nicer objdumps

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,7 @@ SECTIONS
   .text ORIGIN(FLASH) :
   {
     /* Vector table */
+    _VECTOR_TABLE = .;
     LONG(ORIGIN(RAM) + LENGTH(RAM));
     LONG(_reset + 1);
     KEEP(*(.rodata._EXCEPTIONS));


### PR DESCRIPTION
The start of the objdump now looks like this:

```
08000000 <_VECTOR_TABLE>:
 8000000:       2000a000        .word   0x2000a000
 8000004:       08000195        .word   0x08000195
```

instead of like this:

```
08000000 <_EXCEPTIONS-0x8>:
 8000000:       2000a000        .word   0x2000a000
 8000004:       08000195        .word   0x08000195
```