### PR TITLE
update panic-semihosting to 0.3.0 to use #[panic_implementation]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
 
     - env: TARGET=thumbv7em-none-eabi
-      rust: nightly
+      rust: nightly-2018-06-20
       addons:
         apt:
           packages:
             - gcc-arm-none-eabi
 
     - env: TARGET=thumbv7em-none-eabihf
-      rust: nightly
+      rust: nightly-2018-06-20
       addons:
         apt:
           packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = "0.5.0"
 cortex-m-rt = "0.5.0"
 cortex-m-semihosting = "0.3.0"
 madgwick = "0.1.1"
-panic-semihosting = "0.2.0"
+panic-semihosting = "0.3.0"
 
 [dev-dependencies.byteorder]
 default-features = false


### PR DESCRIPTION
Trying to use the `f3` crate with `rustc 1.28.0-nightly (b68432d56 2018-06-12)` fails to compile with 

```
   |
67 | #[lang = "panic_fmt"]
   | ^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `panic_fmt`

error: aborting due to previous error
```

Following the recommendation in https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875 I bumped `panic-semihosting` to 0.3.0