### PR TITLE
Specify linker for 1.30.0 nightly builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [target.thumbv7em-none-eabi]
 runner = 'arm-none-eabi-gdb'
+linker = 'arm-none-eabi-gcc'
 rustflags = [
   "-C", "link-arg=-Wl,-Tlink.x",
   "-C", "link-arg=-nostartfiles",
@@ -7,6 +8,7 @@ rustflags = [
 
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+linker = 'arm-none-eabi-gcc'
 rustflags = [
   "-C", "link-arg=-Wl,-Tlink.x",
   "-C", "link-arg=-nostartfiles",


### PR DESCRIPTION
Recent nightly is failing to link in my environment, but manually specifying the linker in .cargo/config appears to fix the issue.

Fixes https://github.com/japaric/f3/issues/98