### PR TITLE
Update panic-semihosting dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = "0.5.0"
 cortex-m-rt = "0.5.0"
 cortex-m-semihosting = "0.3.0"
 madgwick = "0.1.1"
-panic-semihosting = "0.3.0"
+panic-semihosting = "0.5.1"
 
 [dev-dependencies.byteorder]
 default-features = false


### PR DESCRIPTION
This fixes the following build error:

   Compiling panic-semihosting v0.3.0
error[E0557]: feature has been removed
  --> /home/jonte/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-semihosting-0.3.0/src/lib.rs:59:12
   |
59 | #![feature(panic_implementation)]
   |            ^^^^^^^^^^^^^^^^^^^^
   |
note: subsumed by `#[panic_handler]`
  --> /home/jonte/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-semihosting-0.3.0/src/lib.rs:59:12
   |
59 | #![feature(panic_implementation)]
   |            ^^^^^^^^^^^^^^^^^^^^

error[E0658]: The attribute `panic_implementation` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
  --> /home/jonte/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-semihosting-0.3.0/src/lib.rs:71:3
   |
71 | #[panic_implementation]
   |   ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(custom_attribute)] to the crate attributes to enable

error: aborting due to 2 previous errors

Some errors occurred: E0557, E0658.
For more information about an error, try `rustc --explain E0557`.