### PR TITLE
Use the rust built-in linker

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,15 +1,19 @@
 [target.thumbv7em-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Tlink.x",
+  "-C", "linker=rust-lld",
+  "-Z", "linker-flavor=ld.lld",
+  "-Z", "thinlto=no",
 ]
 
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Tlink.x",
+  "-C", "linker=rust-lld",
+  "-Z", "linker-flavor=ld.lld",
+  "-Z", "thinlto=no",
 ]
 
 [build]


### PR DESCRIPTION
Switch to the rust built-in linker, according to suggestion from @nicodemus26 in #99.

Fixes  #99 and #98.