### PR TITLE
Update ITM book links

### DIFF
--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -5,7 +5,7 @@
 //! You'll need to uncomment lines 8 and 15 of the `.gdbinit` file.
 //!
 //! You'll also need to connect the SWO pin of the on-board SWD programmer to pin PB3 as shown
-//! [here](https://japaric.github.io/discovery/06-hello-world/README.html).
+//! [here](https://rust-embedded.github.io/discovery/06-hello-world/index.html).
 //!
 //! Finally, you'll need to run `itmdump itm.fifo` (mind the file paths) to receive the message.
 //! Read the documentation of the [`itm`] crate, which provides the `itmdump` tool,  for details.

--- a/src/examples/_01_itm.rs
+++ b/src/examples/_01_itm.rs
@@ -5,7 +5,7 @@
 //! You'll need to uncomment lines 8 and 15 of the `.gdbinit` file.
 //!
 //! You'll also need to connect the SWO pin of the on-board SWD programmer to pin PB3 as shown
-//! [here](https://japaric.github.io/discovery/06-hello-world/README.html).
+//! [here](https://rust-embedded.github.io/discovery/06-hello-world/index.html).
 //!
 //! Finally, you'll need to run `itmdump itm.fifo` (mind the file paths) to receive the message.
 //! Read the documentation of the [`itm`] crate, which provides the `itmdump` tool,  for details.


### PR DESCRIPTION
The old links gave me an 404 error. Would probably be nice to add a redirect to the new location.