### PR TITLE
Replace deprecated `hal::prelude::_embedded_hal_digital_OutputPin` with embedded_hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.6.1"
 l3gd20 = "0.2.0"
 lsm303dlhc = "0.2.0"
 stm32f30x-hal = "0.2.0"
+embedded-hal = "0.2.0"
 
 [dev-dependencies]
 aligned = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["cmoran <cmoran@eri.ucsb.edu>"]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support Crate for the STM32F3DISCOVERY"
 documentation = "https://docs.rs/f3"
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = ["arm", "cortex-m", "stm32"]
 license = "MIT OR Apache-2.0"
 name = "f3"
-repository = "https://github.com/quietlychris/f3"
+repository = "https://github.com/japaric/f3"
 version = "0.6.1"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = ["cmoran <cmoran@eri.ucsb.edu>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support Crate for the STM32F3DISCOVERY"
 documentation = "https://docs.rs/f3"
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = ["arm", "cortex-m", "stm32"]
 license = "MIT OR Apache-2.0"
 name = "f3"
-repository = "https://github.com/japaric/f3"
+repository = "https://github.com/quietlychris/f3"
 version = "0.6.1"
 
 [dependencies]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -34,9 +34,11 @@ fn main() -> ! {
     let mut delay = Delay::new(cp.SYST, clocks);
 
     loop {
-        led.on();
+        let mut result = led.on();
+        assert_eq!(result.is_err(), false);
         delay.delay_ms(1_000_u16);
-        led.off();
+        result = led.off();
+        assert_eq!(result.is_err(), false);
         delay.delay_ms(1_000_u16);
     }
 }

--- a/examples/leds.rs
+++ b/examples/leds.rs
@@ -22,7 +22,8 @@ fn main() -> ! {
     let mut leds = Leds::new(gpioe);
 
     for led in leds.iter_mut() {
-        led.on();
+        let result = led.on();
+        assert_eq!(result.is_err(),false);
     }
 
     loop {}

--- a/examples/roulette.rs
+++ b/examples/roulette.rs
@@ -33,8 +33,10 @@ fn main() -> ! {
     loop {
         for curr in 0..n {
             let next = (curr + 1) % n;
-            leds[curr].off();
-            leds[next].on();
+            let mut result = leds[curr].off();
+            assert_eq!(result.is_err(),false);
+            result = leds[next].on();
+            assert_eq!(result.is_err(),false);
 
             delay.delay_ms(100_u8);
         }

--- a/src/led.rs
+++ b/src/led.rs
@@ -2,7 +2,7 @@
 
 use core::ops;
 
-use hal::prelude::*;
+use embedded_hal::digital::v2::OutputPin;
 
 use hal::gpio::gpioe::{self, PEx, PE10, PE11, PE12, PE13, PE14, PE15, PE8, PE9};
 use hal::gpio::{Output, PushPull};
@@ -164,12 +164,12 @@ ctor!(LD3, LD4, LD5, LD6, LD7, LD8, LD9, LD10);
 
 impl Led {
     /// Turns the LED off
-    pub fn off(&mut self) {
+    pub fn off(&mut self) -> core::result::Result<(),()> {
         self.pex.set_low()
     }
 
     /// Turns the LED on
-    pub fn on(&mut self) {
+    pub fn on(&mut self) -> core::result::Result<(),()> {
         self.pex.set_high()
     }
 }


### PR DESCRIPTION
First, apologies for any inconsistencies with this pull request--this is my first time trying to make any changes to a crate, so I'd really appreciate both your patience and any advice you might have. I'm also fairly new to embedded in general, so there's a good chance this is more than a little rough. 

This pull request replaces the deprecated `hal::prelude::_embedded_hal_digital_OutputPin` struct with the `embedded_hal::digital::v2::OutputPin` struct instead. The now-required `Result` is consumed by an `assert_eq!()` statement to prevent an error due to the `#![deny(warnings)]` flag, which appears in the `blinky`, `leds`, and `roulette` examples. 

I'm not sure if the result is supposed to look like `Result<(),()>` or not, but since the Implementor I see in the [docs](https://docs.rs/embedded-hal/0.2.3/embedded_hal/digital/v2/trait.OutputPin.html#associatedtype.Error-1) says `type Error = ()` and it compiles, I thought that might make sense. I'm also not sure that using `assert_eq!()` is the most idiomatic way of doing error handling in this case, so any guidance there would be appreciated as well. 

I believe this solves the issue referenced in this [comment](https://github.com/japaric/f3/issues/106#issuecomment-520590980).