### PR TITLE
Lower Profile Changes to make Crate and Examples build with Rust 1.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ stm32f30x-hal = "0.2.0"
 
 [dev-dependencies]
 aligned = "0.3.2"
+as-slice = "0.1.3"
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.5"
 cortex-m-semihosting = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ lsm303dlhc = "0.2.0"
 stm32f30x-hal = "0.2.0"
 
 [dev-dependencies]
-aligned = "0.2.0"
-cortex-m = "0.5.0"
+aligned = "0.3.2"
+cortex-m = "0.6.2"
 cortex-m-rt = "0.6.5"
 cortex-m-semihosting = "0.3.2"
 madgwick = "0.1.1"

--- a/examples/l3gd20.rs
+++ b/examples/l3gd20.rs
@@ -30,7 +30,10 @@ fn main() -> ! {
     let mut nss = gpioe
         .pe3
         .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
-    nss.set_high();
+    {
+        #![allow(deprecated)]
+        nss.set_high();
+    }
 
     // The `L3gd20` abstraction exposed by the `f3` crate requires a specific pin configuration to
     // be used and won't accept any configuration other than the one used here. Trying to use a

--- a/examples/log-sensors.rs
+++ b/examples/log-sensors.rs
@@ -37,7 +37,8 @@ extern crate panic_semihosting;
 
 use core::ptr;
 
-use aligned::Aligned;
+use aligned::{Aligned, A4};
+use as_slice::AsMutSlice;
 use byteorder::{ByteOrder, LE};
 use cortex_m::{asm, itm};
 use cortex_m_rt::entry;
@@ -148,7 +149,7 @@ fn main() -> ! {
     itm::write_all(&mut cp.ITM.stim[0], &[0]);
 
     // Capture N samples
-    let mut tx_buf: Aligned<u32, [u8; 20]> = Aligned([0; 20]);
+    let mut tx_buf: Aligned<A4, [u8; 20]> = Aligned([0; 20]);
     for _ in 0..NSAMPLES {
         block!(timer.wait()).unwrap();
 
@@ -182,7 +183,7 @@ fn main() -> ! {
         LE::write_i16(&mut buf[start..start + 2], g.z);
 
         // Log data
-        cobs::encode(&buf, &mut tx_buf);
+        cobs::encode(&buf, tx_buf.as_mut_slice());
 
         itm::write_aligned(&mut cp.ITM.stim[0], &tx_buf);
     }

--- a/examples/log-sensors.rs
+++ b/examples/log-sensors.rs
@@ -120,7 +120,10 @@ fn main() -> ! {
     let mut nss = gpioe
         .pe3
         .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
-    nss.set_high();
+    {
+        #![allow(deprecated)]
+        nss.set_high();
+    }
     let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
     let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
     let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);

--- a/examples/madgwick.rs
+++ b/examples/madgwick.rs
@@ -130,7 +130,11 @@ fn main() -> ! {
     let mut nss = gpioe
         .pe3
         .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
-    nss.set_high();
+    {
+        #![allow(deprecated)]
+        nss.set_high();
+    }
+
     let mut led = gpioe
         .pe9
         .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper);
@@ -182,7 +186,10 @@ fn main() -> ! {
     let ar_bias_z = (ar_bias_z / NSAMPLES) as i16;
 
     // Turn on the LED after calibrating the gyroscope
-    led.set_high();
+    {
+        #![allow(deprecated)]
+        led.set_high();
+    }
 
     let mut marg = Marg::new(BETA, 1. / f32(SAMPLE_FREQ));
     let mut timer = Timer::tim2(timer.free(), SAMPLE_FREQ.hz(), clocks, &mut rcc.apb1);

--- a/examples/madgwick.rs
+++ b/examples/madgwick.rs
@@ -38,7 +38,8 @@ extern crate panic_semihosting;
 
 use core::{f32::consts::PI, ptr};
 
-use aligned::Aligned;
+use aligned::{Aligned, A4};
+use as_slice::AsMutSlice;
 use byteorder::{ByteOrder, LE};
 use cast::{f32, i32};
 use cortex_m::itm;
@@ -194,7 +195,7 @@ fn main() -> ! {
     let mut marg = Marg::new(BETA, 1. / f32(SAMPLE_FREQ));
     let mut timer = Timer::tim2(timer.free(), SAMPLE_FREQ.hz(), clocks, &mut rcc.apb1);
 
-    let mut tx_buf: Aligned<u32, [u8; 18]> = Aligned([0; 18]);
+    let mut tx_buf: Aligned<A4, [u8; 18]> = Aligned([0; 18]);
     loop {
         block!(timer.wait()).unwrap();
 
@@ -248,7 +249,7 @@ fn main() -> ! {
         // start += 4;
 
         // Log data
-        cobs::encode(&buf, &mut tx_buf.array);
+        cobs::encode(&buf, tx_buf.as_mut_slice());
 
         itm::write_aligned(&mut cp.ITM.stim[0], &tx_buf);
     }

--- a/src/led.rs
+++ b/src/led.rs
@@ -165,11 +165,13 @@ ctor!(LD3, LD4, LD5, LD6, LD7, LD8, LD9, LD10);
 impl Led {
     /// Turns the LED off
     pub fn off(&mut self) {
+        #![allow(deprecated)]
         self.pex.set_low()
     }
 
     /// Turns the LED on
     pub fn on(&mut self) {
+        #![allow(deprecated)]
         self.pex.set_high()
     }
 }

--- a/viz/.cargo/config
+++ b/viz/.cargo/config
@@ -1,0 +1,9 @@
+[build]
+# Configure the build target to your host platform. See
+# https://forge.rust-lang.org/release/platform-support.html#tier-1 for details
+# and uncomment or add the appropriate line for your host below.
+#
+# target = "x86_64-apple-darwin"
+# target = "x86_64-pc-windows-gnu"
+# target = "x86_64-unknown-linux-gnu"
+

--- a/viz/Cargo.toml
+++ b/viz/Cargo.toml
@@ -7,5 +7,5 @@ version = "0.1.0"
 [dependencies]
 byteorder = "1.2.1"
 cobs = "0.1.3"
-kiss3d = "0.13.0"
-nalgebra = "0.14.0"
+kiss3d = "0.24.1"
+nalgebra = "0.21.1"

--- a/viz/README.md
+++ b/viz/README.md
@@ -1,0 +1,21 @@
+# `f3` Madgwick Example Visualization
+
+This is the visualization application for `../examples/madgwick.rs` to run on
+your host.
+
+
+## Building
+
+The `f3` crate already configures its build target to `thumbv7em-none-eabihf`
+and so we have to explicitly specify it when building and running the
+visualization in place.
+
+The most convenient way is likely to edit `./.cargo/config` to select your host
+platform.
+
+Alternatively you can explicitly specify it when building and running the
+application. For example for Linux x86\_64:
+```
+$ cargo build --target x86_64-unknown-linux-gnu
+$ cargo run --target x86_64-unknown-linux-gnu
+```

--- a/viz/src/main.rs
+++ b/viz/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
 fn parse(sender: &mut Sender<(f32, f32, f32, f32)>) {
     let stdin = io::stdin();
 
-    for mut frame in BufReader::new(stdin.lock()).split(0) {
+    for frame in BufReader::new(stdin.lock()).split(0) {
         let mut frame = frame.unwrap();
         if let Ok(n) = cobs::decode_in_place(&mut frame) {
             if n == 16 {


### PR DESCRIPTION
#109 switches to another STM32F3 HAL to solve the current issues when building with Rust 1.44. These are breaking changes delaying the integration.

What about some smaller dependecy updates and hot fixing the deprecation warnings for getting the great examples from this create up and running again as a minor update? This would also solve #110.

I did not update the crate version and would leave this up to you @japaric. 